### PR TITLE
fix heroku app name for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ script:
   - bundle exec rake
 deploy:
   provider: heroku
+  app: agile-wildwood-37674
   api_key:
     secure: "bc26c969-a3b6-4f11-ad55-bd8ba0846446"


### PR DESCRIPTION
The app name was not setted and different on heroku, thus failing upon deployment from travis to heroku.
